### PR TITLE
Remove needless `unsafe Send + Sync` implementations

### DIFF
--- a/src/async_kcp/stream.rs
+++ b/src/async_kcp/stream.rs
@@ -603,7 +603,3 @@ impl AsyncWrite for KcpStream {
         Poll::Ready(Ok(()))
     }
 }
-
-// Make KcpStream safe to send between threads
-unsafe impl Send for KcpStream {}
-unsafe impl Sync for KcpStream {}


### PR DESCRIPTION
`KcpStream` already is `Send + Sync`. No need to for the explicit implementations.